### PR TITLE
Update index.html

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -72,7 +72,7 @@
                             <span id="searchSpan" class="input-group-addon" data-toggle="popover" title="Selektoren" data-trigger="hover" data-html="true" data-placement="bottom" data-content="!Sender</br>#Thema</br>+Titel</br>*Beschreibung">Suche</span>
                             <input id="queryInput" type="text" class="form-control" autofocus>
                         </div>
-                        <a onclick="return false;" tabIndex="-1"><i id="queryInputClearButton" class="material-icons" tabIndex="-1">clear</i></a>
+                        <a onclick="return false;" tabIndex="-1"><i id="queryInputClearButton" class="material-icons">clear</i></a>
                     </div>
 
                     <div class="col-lg-4 col-md-5 col-sm-5">


### PR DESCRIPTION
validator.w3.org complains that tabindex must not appear as a descendant of the a element. Fix this by removing the tabindex, which is not needed here.