### PR TITLE
Add video file as enclosure in RSS feed item

### DIFF
--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -94,7 +94,10 @@ export default class RSSFeedGenerator {
             description: item.description,
             url: item.url_video_hd || item.url_video,
             guid: item.id,
-            date: new Date(item.timestamp * 1000)
+            date: new Date(item.timestamp * 1000),
+            enclosure: {
+              url: item.url_video_hd || item.url_video
+            }
           });
         }
 

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -96,7 +96,8 @@ export default class RSSFeedGenerator {
             guid: item.id,
             date: new Date(item.timestamp * 1000),
             enclosure: {
-              url: item.url_video_hd || item.url_video
+              url: item.url_video_hd || item.url_video,
+              size: item.size
             }
           });
         }


### PR DESCRIPTION
Hi,

this PR sets the video url as an attached media object to the RSS feed item. This should fix #75.

Possible enhancements to this PR would be the mime type of the video, but I wasn't sure how to get this data from the elaticsearch result.

```ts
            enclosure: {
              url: item.url_video_hd || item.url_video,
              type: '', // mime type?
              size: item.size
            }
```

Also see the RSS spec as reference: http://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt