### PR TITLE
added duration in seconds as custom_element in the rss feed.

### DIFF
--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -98,7 +98,12 @@ export default class RSSFeedGenerator {
             enclosure: {
               url: item.url_video_hd || item.url_video,
               size: item.size
-            }
+            },
+            custom_elements: [
+              {
+                duration: item.duration
+              }
+            ]
           });
         }
 


### PR DESCRIPTION
With this enhancement rss clients are able to check the duration of a certain tv show. Would appreciate a merge.