### PR TITLE
Add websiteUrl to RSS item

### DIFF
--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -102,7 +102,10 @@ export default class RSSFeedGenerator {
             custom_elements: [
               {
                 duration: item.duration
-              }
+              },
+              {
+                websiteUrl: item.website_url
+              },
             ]
           });
         }


### PR DESCRIPTION
The `video_url` is already present in the enclosure item and the website url may provide more value to some users.