### PR TITLE
Remove unnecessary type attribute

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="/static/index.css" />
 
   <!-- Add Polyfills if using Internet Explorer -->
-  <script type="text/javascript">
+  <script>
     if (window.navigator.userAgent.indexOf("MSIE ") > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./)) {
       var script = document.createElement('script');
       script.type = 'text/javascript';


### PR DESCRIPTION
The type attribute is unnecessary for JavaScript resources, according to W3C.