### PR TITLE
duration search filter using < and > in seconds

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -132,6 +132,8 @@ function parseQuery(query) {
   const titles = [];
   const descriptions = [];
   let generics = [];
+  let duration_min = -1;
+  let duration_max = 9999999;
 
   const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
     return (split.length > 0);

--- a/client/index.ts
+++ b/client/index.ts
@@ -170,6 +170,20 @@ function parseQuery(query) {
       if (d.length > 0) {
         descriptions.push(d);
       }
+    } else if (split[0] == '>') {
+      const d = split.slice(1, split.length).split(',').filter((split) => {
+        return (split.length > 0);
+      });
+      if (d.length > 0 && !isNaN(d[0])) {
+        duration_min=d[0]*1;
+      }
+    } else if (split[0] == '<') {
+      const d = split.slice(1, split.length).split(',').filter((split) => {
+        return (split.length > 0);
+      });
+      if (d.length > 0 && !isNaN(d[0])) {
+        duration_max=d[0]*1;
+      }    
     } else {
       generics = generics.concat(split.split(/\s+/));
     }
@@ -180,6 +194,8 @@ function parseQuery(query) {
     topics: topics,
     titles: titles,
     descriptions: descriptions,
+    duration_min: duration_min,
+    duration_max: duration_max,
     generics: generics
   }
 }
@@ -397,6 +413,8 @@ const query = _.throttle(() => {
     sortBy: 'timestamp',
     sortOrder: 'desc',
     future: future,
+    duration_min: parsedQuery.duration_min,
+    duration_max: parsedQuery.duration_max,
     offset: currentPage * itemsPerPage,
     size: itemsPerPage
   };

--- a/server/ElasticsearchDefinitions.ts
+++ b/server/ElasticsearchDefinitions.ts
@@ -41,7 +41,7 @@ export const mapping = {
     },
     size: {
       type: 'long',
-      index: true
+      index: false
     },
     url_video: {
       type: 'keyword',

--- a/server/ElasticsearchDefinitions.ts
+++ b/server/ElasticsearchDefinitions.ts
@@ -37,11 +37,11 @@ export const mapping = {
     },
     duration: {
       type: 'long',
-      index: false
+      index: true
     },
     size: {
       type: 'long',
-      index: false
+      index: true
     },
     url_video: {
       type: 'keyword',

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -57,6 +57,8 @@ export default class RSSFeedGenerator {
       sortBy: 'timestamp',
       sortOrder: 'desc',
       future: urlQuery.future || false,
+      duration_min: urlQuery.duration_min,
+      duration_max: urlQuery.duration_max,
       offset: 0,
       size: 50
     };

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -124,6 +124,8 @@ export default class RSSFeedGenerator {
     const titles = [];
     const descriptions = [];
     let generics = [];
+    let duration_min = -1;
+    let duration_max = 9999999;
 
     const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
       return (split.length > 0);
@@ -160,6 +162,20 @@ export default class RSSFeedGenerator {
         if (d.length > 0) {
           descriptions.push(d);
         }
+      } else if (split[0] == '>') {
+        const d = split.slice(1, split.length).split(',').filter((split) => {
+          return (split.length > 0);
+        });
+        if (d.length > 0 && !isNaN(d[0])) {
+          duration_min=d[0]*1;
+        }
+      } else if (split[0] == '<') {
+        const d = split.slice(1, split.length).split(',').filter((split) => {
+          return (split.length > 0);
+        });
+        if (d.length > 0 && !isNaN(d[0])) {
+          duration_max=d[0]*1;
+        }
       } else {
         generics = generics.concat(split.split(/\s+/));
       }
@@ -170,6 +186,8 @@ export default class RSSFeedGenerator {
       topics: topics,
       titles: titles,
       descriptions: descriptions,
+      duration_min: duration_min,
+      duration_max: duration_max,
       generics: generics
     }
   }

--- a/server/SearchEngine.ts
+++ b/server/SearchEngine.ts
@@ -149,6 +149,18 @@ export default class SearchEngine {
       }
     }
 
+    if (query.duration_max && query.duration_min) {
+      let durationFilter = {
+        range: {
+          duration: {
+            lt: query.duration_max,
+            gt: query.duration_min
+          }
+        }
+      };
+      elasticQuery.body.query.bool.filter.push(durationFilter);
+    }
+
     if (query.future === false) {
       let rangeFilter = {
         range: {


### PR DESCRIPTION
Sometimes you are just looking for movies (i.e. something long) or something particularly short. Up to know that's not possible for the web version in contrast to the desktop app. It would be nice to have this feature included using < and > for indicating maximum/minimum duration. 

Admittedly I am for from being an expert on elasticsearch et  al. My solution does not work, I get an error stating "duration" is not indexed which I cannot solve. It's hopefully easy for you.

Since I could not test my code: you might want to add *60 while parsing the parameters to convert the input into seconds. Also my implementation really sticks to the true meaning of < and >, i.e. true less than and greater than (not equals). Maybe you want to change this.