### PR TITLE
duration search filter using < and > in seconds

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -93,7 +93,7 @@
           <div class="col-lg-8 col-md-7 col-sm-7">
             <div class="input-group">
               <span id="searchSpan" class="input-group-addon" data-toggle="popover" title="Selektoren" data-trigger="hover"
-                    data-html="true" data-placement="bottom" data-content="!Sender</br>#Thema</br>+Titel</br>*Beschreibung">Suche</span>
+                    data-html="true" data-placement="bottom" data-content="!Sender</br>#Thema</br>+Titel</br>*Beschreibung</br><x (in minuten)</br>>x (in minuten)">Suche</span>
               <input id="queryInput" type="text" class="form-control" autofocus>
             </div>
             <a tabIndex="-1"><i id="queryInputClearButton" class="material-icons">clear</i></a>

--- a/client/index.ts
+++ b/client/index.ts
@@ -132,6 +132,8 @@ function parseQuery(query) {
   const titles = [];
   const descriptions = [];
   let generics = [];
+  let duration_min = -1;
+  let duration_max = 9999999;
 
   const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
     return (split.length > 0);

--- a/client/index.ts
+++ b/client/index.ts
@@ -170,6 +170,20 @@ function parseQuery(query) {
       if (d.length > 0) {
         descriptions.push(d);
       }
+    } else if (split[0] == '>') {
+      const d = split.slice(1, split.length).split(',').filter((split) => {
+        return (split.length > 0);
+      });
+      if (d.length > 0 && !isNaN(d[0])) {
+        duration_min=d[0]*1;
+      }
+    } else if (split[0] == '<') {
+      const d = split.slice(1, split.length).split(',').filter((split) => {
+        return (split.length > 0);
+      });
+      if (d.length > 0 && !isNaN(d[0])) {
+        duration_max=d[0]*1;
+      }    
     } else {
       generics = generics.concat(split.split(/\s+/));
     }
@@ -180,6 +194,8 @@ function parseQuery(query) {
     topics: topics,
     titles: titles,
     descriptions: descriptions,
+    duration_min: duration_min,
+    duration_max: duration_max,
     generics: generics
   }
 }
@@ -397,6 +413,8 @@ const query = _.throttle(() => {
     sortBy: 'timestamp',
     sortOrder: 'desc',
     future: future,
+    duration_min: parsedQuery.duration_min,
+    duration_max: parsedQuery.duration_max,
     offset: currentPage * itemsPerPage,
     size: itemsPerPage
   };

--- a/client/index.ts
+++ b/client/index.ts
@@ -132,8 +132,8 @@ function parseQuery(query) {
   const titles = [];
   const descriptions = [];
   let generics = [];
-  let duration_min = -1;
-  let duration_max = 9999999;
+  let duration_min = undefined;
+  let duration_max = undefined;
 
   const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
     return (split.length > 0);
@@ -175,15 +175,15 @@ function parseQuery(query) {
         return (split.length > 0);
       });
       if (d.length > 0 && !isNaN(d[0])) {
-        duration_min=d[0]*1;
+        duration_min = d[0] * 60;
       }
     } else if (split[0] == '<') {
       const d = split.slice(1, split.length).split(',').filter((split) => {
         return (split.length > 0);
       });
       if (d.length > 0 && !isNaN(d[0])) {
-        duration_max=d[0]*1;
-      }    
+        duration_max = d[0] * 60;
+      }
     } else {
       generics = generics.concat(split.split(/\s+/));
     }
@@ -1011,17 +1011,17 @@ $(() => {
       clearButton.animate({
         opacity: 0
       }, {
-          easing: 'swing',
-          duration: 20
-        });
+        easing: 'swing',
+        duration: 20
+      });
       queryInputClearButtonState = 'hidden';
     } else if (currentQueryString.length > 0 && queryInputClearButtonState == 'hidden') {
       clearButton.animate({
         opacity: 1
       }, {
-          easing: 'swing',
-          duration: 20
-        });
+        easing: 'swing',
+        duration: 20
+      });
       queryInputClearButtonState = 'shown';
     }
   });

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -1,68 +1,20 @@
 version: "3.7"
 
 services:
-  application:
-    container_name: mediathekviewweb
-    image: mediathekview/mediathekviewweb:development
-    restart: always
-    depends_on:
-      - elasticsearch
-      - redis
-    environment:
-      DATA_DIRECTORY: /data
-      WEBSERVER_PORT: 8000
-      INDEX: true
-      WORKER_COUNT:
-      WORKER_ARGS:
-      REDIS_HOST: redis
-      REDIS_PORT:
-      REDIS_PASSWORD:
-      REDIS_DB:
-      ELASTICSEARCH_HOST: elasticsearch
-      ELASTICSEARCH_PORT: 9200
-      MATOMO_ENABLED:
-      MATOMO_URL:
-      MATOMO_SITE_URL:
-      MATOMO_AUTH_TOKEN:
-      MATOMO_SITE_ID:
-      CONTACT_NAME:
-      CONTACT_STREET:
-      CONTACT_POSTCODE:
-      CONTACT_CITY:
-      CONTACT_MAIL:
-    volumes:
-      - "mediathekviewweb:/data"
-    ports:
-      - "8001:8000"
-    networks:
-      - elasticsearch
-      - redis
-
   elasticsearch:
-    container_name: elasticsearch
-    image: "docker.elastic.co/elasticsearch/elasticsearch:6.7.2"
-    restart: always
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.8
     environment:
-      - ES_JAVA_OPTS=-Xms2G -Xmx2G
-    volumes:
-      - "elasticsearch:/usr/share/elasticsearch/data"
-    networks:
-      - elasticsearch
+      discovery.type: single-node
+    container_name: elasticsearch
+    tmpfs:
+      - /usr/share/elasticsearch/data/
+    ports:
+      - "9200:9200"
 
   redis:
     container_name: redis
-    image: "redis:5.0-alpine"
-    restart: always
-    volumes:
-      - "redis:/data"
-    networks:
-      - redis
-
-volumes:
-  mediathekviewweb:
-  redis:
-  elasticsearch:
-
-networks:
-  elasticsearch:
-  redis:
+    image: redis:5-alpine
+    tmpfs:
+      - /data
+    ports:
+      - "6379:6379"

--- a/server/ElasticsearchDefinitions.ts
+++ b/server/ElasticsearchDefinitions.ts
@@ -41,7 +41,7 @@ export const mapping = {
     },
     size: {
       type: 'long',
-      index: true
+      index: false
     },
     url_video: {
       type: 'keyword',

--- a/server/ElasticsearchDefinitions.ts
+++ b/server/ElasticsearchDefinitions.ts
@@ -37,11 +37,11 @@ export const mapping = {
     },
     duration: {
       type: 'long',
-      index: false
+      index: true
     },
     size: {
       type: 'long',
-      index: false
+      index: true
     },
     url_video: {
       type: 'keyword',

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -57,6 +57,8 @@ export default class RSSFeedGenerator {
       sortBy: 'timestamp',
       sortOrder: 'desc',
       future: urlQuery.future || false,
+      duration_min: urlQuery.duration_min,
+      duration_max: urlQuery.duration_max,
       offset: 0,
       size: 50
     };

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -124,8 +124,8 @@ export default class RSSFeedGenerator {
     const titles = [];
     const descriptions = [];
     let generics = [];
-    let duration_min = -1;
-    let duration_max = 9999999;
+    let duration_min = undefined;
+    let duration_max = undefined;
 
     const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
       return (split.length > 0);
@@ -167,14 +167,14 @@ export default class RSSFeedGenerator {
           return (split.length > 0);
         });
         if (d.length > 0 && !isNaN(d[0])) {
-          duration_min=d[0]*1;
+          duration_min = d[0] * 60;
         }
       } else if (split[0] == '<') {
         const d = split.slice(1, split.length).split(',').filter((split) => {
           return (split.length > 0);
         });
         if (d.length > 0 && !isNaN(d[0])) {
-          duration_max=d[0]*1;
+          duration_max = d[0] * 60;
         }
       } else {
         generics = generics.concat(split.split(/\s+/));

--- a/server/RSSFeedGenerator.ts
+++ b/server/RSSFeedGenerator.ts
@@ -124,6 +124,8 @@ export default class RSSFeedGenerator {
     const titles = [];
     const descriptions = [];
     let generics = [];
+    let duration_min = -1;
+    let duration_max = 9999999;
 
     const splits = query.trim().toLowerCase().split(/\s+/).filter((split) => {
       return (split.length > 0);
@@ -160,6 +162,20 @@ export default class RSSFeedGenerator {
         if (d.length > 0) {
           descriptions.push(d);
         }
+      } else if (split[0] == '>') {
+        const d = split.slice(1, split.length).split(',').filter((split) => {
+          return (split.length > 0);
+        });
+        if (d.length > 0 && !isNaN(d[0])) {
+          duration_min=d[0]*1;
+        }
+      } else if (split[0] == '<') {
+        const d = split.slice(1, split.length).split(',').filter((split) => {
+          return (split.length > 0);
+        });
+        if (d.length > 0 && !isNaN(d[0])) {
+          duration_max=d[0]*1;
+        }
       } else {
         generics = generics.concat(split.split(/\s+/));
       }
@@ -170,6 +186,8 @@ export default class RSSFeedGenerator {
       topics: topics,
       titles: titles,
       descriptions: descriptions,
+      duration_min: duration_min,
+      duration_max: duration_max,
       generics: generics
     }
   }

--- a/server/SearchEngine.ts
+++ b/server/SearchEngine.ts
@@ -149,6 +149,18 @@ export default class SearchEngine {
       }
     }
 
+    if (query.duration_max && query.duration_min) {
+      let durationFilter = {
+        range: {
+          duration: {
+            lt: query.duration_max,
+            gt: query.duration_min
+          }
+        }
+      };
+      elasticQuery.body.query.bool.filter.push(durationFilter);
+    }
+
     if (query.future === false) {
       let rangeFilter = {
         range: {

--- a/server/SearchEngine.ts
+++ b/server/SearchEngine.ts
@@ -149,15 +149,21 @@ export default class SearchEngine {
       }
     }
 
-    if (query.duration_max && query.duration_min) {
-      let durationFilter = {
+    if (query.duration_min != undefined || query.duration_max != undefined) {
+      const durationFilter = {
         range: {
-          duration: {
-            lt: query.duration_max,
-            gt: query.duration_min
-          }
+          duration: {} as { gt?: number, lt?: number }
         }
       };
+
+      if (query.duration_min != undefined) {
+        durationFilter.range.duration.gt = query.duration_min;
+      }
+
+      if (query.duration_max != undefined) {
+        durationFilter.range.duration.lt = query.duration_max;
+      }
+
       elasticQuery.body.query.bool.filter.push(durationFilter);
     }
 


### PR DESCRIPTION
Sometimes you are just looking for movies (i.e. something long) or something particularly short. Up to know that's not possible for the web version in contrast to the desktop app. It would be nice to have this feature included using < and > for indicating maximum/minimum duration.

Admittedly I am for from being an expert on elasticsearch et al. My solution does not work, I get an error stating "duration" is not indexed which I cannot solve. It's hopefully easy for you.

Since I could not test my code: you might want to add *60 while parsing the parameters to convert the input into seconds. Also my implementation really sticks to the true meaning of < and >, i.e. true less than and greater than (not equals). Maybe you want to change this.