### PR TITLE
fix(docker-compose): syntax error in docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       DATA_DIRECTORY: /data
       WEBSERVER_PORT: 8000
-      INDEX: true
+      INDEX: 'true'
       WORKER_COUNT:
       WORKER_ARGS:
       REDIS_HOST: redis


### PR DESCRIPTION
Environment variable does not allow booleans like this. Change to true.
