### PR TITLE
Suche nach Dauer dokumentieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Da die Abfrage auf dem Server durchgeführt wird, die Anforderungen an das Endge
 
 - "#tagesschau \*klima" zeigt alle Beiträge der "Tagesschau", die "Klima" in der Beschreibung enthalten.
 
+- ">60" zeigt Beiträge, die länger als 60 Minuten dauern. Der Operator "<" wird analog unterstützt.
+
 
 ##### Das Komma ist der "und" Operator
 


### PR DESCRIPTION
Der Query-Parser unterstützt auch die Einschränkung der Suchdauer. Diese ist jedoch nicht im Readme dokumentiert. Ich habe ein Beispiel hinzugefügt.