### PR TITLE
mention cookie requirement, resolves #168

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -106,7 +106,7 @@
 
       <div id="browserWarning" class="showafter1s" style="border: 3px solid red; padding: 10px; margin: 15px">
         <span><a target="_blank" href="https://github.com/mediathekview/mediathekviewweb/issues/8">Dein Browser wird
-            nicht unterstützt</a> oder Javascript ist deaktiviert</span>
+            nicht unterstützt</a> oder Cookies oder Javascript ist/sind deaktiviert.</span>
       </div>
 
       <div id="main-view">


### PR DESCRIPTION
The main page displays a error box “your browser is not supported or JavaScript is disabled” even though the root cause is that Cookies are disabled. This is very confusing. This change mentions Cookies in the message as well. Evidently, the best solution would be not to require cookies at all.