### PR TITLE
Avoid crypto.randomUUID() TypeError by adding uuid helper

### DIFF
--- a/client/src/lib/components/Toggle.svelte
+++ b/client/src/lib/components/Toggle.svelte
@@ -3,10 +3,11 @@
     label: string;
     checked?: boolean;
   }
+  import { uuid } from '$lib/uuid';
 
   let { label, checked = $bindable(), class: extraClass = '', ...rest }: Props = $props();
 
-  const id = `toggle-${crypto.randomUUID()}`;
+  const id = `toggle-${uuid()}`;
 </script>
 
 <div class="flex items-center gap-2 {extraClass}">

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { uuid } from './uuid';
+
 declare const umami: {
   track: (event_name: string, data?: Record<string, any>) => void;
   identify: (unique_id: string) => void;
@@ -11,7 +13,7 @@ export function initializeAnalytics(): void {
     const umamiIdKey = 'mvw_uuid';
     let uniqueId = localStorage.getItem(umamiIdKey);
     if (!uniqueId) {
-      uniqueId = crypto.randomUUID();
+      uniqueId = uuid();
       localStorage.setItem(umamiIdKey, uniqueId);
     }
     umami.identify(uniqueId);

--- a/client/src/lib/uuid.ts
+++ b/client/src/lib/uuid.ts
@@ -1,0 +1,23 @@
+export function uuid(): string {
+  if (typeof globalThis !== 'undefined' && globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  if (typeof globalThis !== 'undefined' && globalThis.crypto && typeof globalThis.crypto.getRandomValues === 'function') {
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+    // RFC4122 v4
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+  }
+
+  // Last-resort fallback (not cryptographically secure)
+  const hexChars = '0123456789abcdef';
+  const s: string[] = new Array(36);
+  for (let i = 0; i < 36; i++) s[i] = hexChars[(Math.random() * 16) | 0];
+  s[14] = '4';
+  s[19] = hexChars[(parseInt(s[19], 16) & 0x3) | 0x8];
+  s[8] = s[13] = s[18] = s[23] = '-';
+  return s.join('');
+}


### PR DESCRIPTION
The client currently calls `crypto.randomUUID()` directly (notably in `initializeAnalytics` and `Toggle`). In environments where `crypto.randomUUID` is not available, this throws a `TypeError` and crashes the frontend, causing the app to show a fallback "Browser not supported / JavaScript disabled" banner.
This PR introduces a small `uuid()` helper and replaces direct calls to `crypto.randomUUID()` with `uuid()`, preventing the crash and improving compatibility.
Changes

client/src/lib/uuid.ts (new)
Adds uuid(): string which:
returns native crypto.randomUUID() if present
otherwise builds an RFC4122 v4 UUID using crypto.getRandomValues() if available
otherwise uses a last-resort Math.random() based UUID
client/src/lib/utils.ts (modified)
import { uuid } from '$lib/uuid';
replace uniqueId = crypto.randomUUID() with uniqueId = uuid();
client/src/lib/components/Toggle.svelte (modified)
import { uuid } from '$lib/uuid';
replace toggle id generation to use uuid()
Rationale

Avoids runtime crash on browsers/environments without crypto.randomUUID
Keeps behavior deterministic: still uses secure randomness when available
Minimal change surface and no new runtime dependency
Risk and backward compatibility

The only functional change is how the UUID is created when the native function is missing.
Analytics ID stored in localStorage continues to be a string UUID, so downstream code continues to work.
If maintainers prefer a global polyfill for crypto.randomUUID(), that can be done instead; this PR chooses an explicit helper to avoid mutating global state.


<img width="1000" height="247" alt="Screenshot From 2025-12-07 19-20-48" src="https://github.com/user-attachments/assets/0bcc1c28-a238-4b69-a613-6e0862f08f87" />


