### PR TITLE
Add Google Cast support

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "@sveltejs/vite-plugin-svelte": "6.2",
         "@tailwindcss/vite": "4.1",
         "@tsconfig/svelte": "5.0",
+        "@types/chromecast-caf-sender": "^1.0.11",
         "@types/node": "24",
         "@types/video.js": "7.3",
         "prettier": "3.6",
@@ -878,7 +879,6 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -1220,10 +1220,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chrome": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.38.tgz",
+      "integrity": "sha512-5aK4m9wZqoWAoB98aElESLm/5pXpqJnFWMNoiCs/XdPsXR6wNdVkJFSdQ9Wr4PnTuUrxD0SuNuDHh3EG5QeBzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/chromecast-caf-sender": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/chromecast-caf-sender/-/chromecast-caf-sender-1.0.11.tgz",
+      "integrity": "sha512-Pv3xvNYtxD/cTM/tKfuZRlLasvpxAm+CFni0GJd6Cp8XgiZS9g9tMZkR1uymsi5fIFv057SZKKAWVFFgy7fJtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chrome": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1233,7 +1278,6 @@
       "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -1308,7 +1352,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1992,7 +2035,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2060,7 +2102,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2077,7 +2118,6 @@
       "integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "prettier": "^3.0.0",
         "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -2256,7 +2296,6 @@
       "integrity": "sha512-wr/SwBVCVfeHU8FZr48vRrzSpWdBBzGo5mlErjGzeW4reJhK/CWutLZbk/eHwhKqO17ccjeTcvsqjrT4aK3wZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2305,8 +2344,7 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -2362,7 +2400,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2403,7 +2440,6 @@
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.4.tgz",
       "integrity": "sha512-qI0VTlYmKzEqRsz1Nppdfcaww4RSxZAq77z2oNSl3cNg2h6do5C8Ffl0KqWQ1OpD8desWXsCrde7tKJ9gGTEyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "^3.17.2",
@@ -2456,7 +2492,6 @@
       "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@sveltejs/vite-plugin-svelte": "6.2",
     "@tailwindcss/vite": "4.1",
     "@tsconfig/svelte": "5.0",
+    "@types/chromecast-caf-sender": "^1.0.11",
     "@types/node": "24",
     "@types/video.js": "7.3",
     "prettier": "3.6",

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import CastConsentDialog from '$lib/components/CastConsentDialog.svelte';
   import ContactDialog from '$lib/components/ContactDialog.svelte';
   import CookieDialog from '$lib/components/CookieDialog.svelte';
   import Datenschutz from '$lib/components/Datenschutz.svelte';
@@ -9,6 +10,7 @@
   import ResultsContainer from '$lib/components/ResultsContainer.svelte';
   import SearchBar from '$lib/components/SearchBar.svelte';
   import VideoPlayer from '$lib/components/VideoPlayer.svelte';
+  import { setCastConsentProvider } from '$lib/cast';
   import { appState } from '$lib/store.svelte';
   import type { VideoPayload } from '$lib/types';
   import { initializeAnalytics, trackEvent } from '$lib/utils';
@@ -18,6 +20,7 @@
   let cookieDialog: CookieDialog;
   let contactDialog: ContactDialog;
   let donateDialog: DonateDialog;
+  let castConsentDialog: CastConsentDialog;
   let mainElement: HTMLElement;
   let legalDialog = $state<Dialog>();
 
@@ -72,6 +75,16 @@
 
     // This now correctly starts the reactive effects and returns a cleanup function
     const destroyStore = appState.init();
+
+    setCastConsentProvider(
+      () =>
+        new Promise((resolve) => {
+          castConsentDialog.show((choice) => {
+            trackEvent('Cast Consent', { consent: choice });
+            resolve(choice);
+          });
+        }),
+    );
 
     // Cookie consent
     try {
@@ -133,6 +146,7 @@
 
 <VideoPlayer videoPayload={videoToPlay} onClose={() => (videoToPlay = null)} />
 <CookieDialog bind:this={cookieDialog} onConsent={handleCookieConsent} {showImpressum} {showDatenschutz} />
+<CastConsentDialog bind:this={castConsentDialog} />
 <ContactDialog bind:this={contactDialog} />
 <DonateDialog bind:this={donateDialog} />
 

--- a/client/src/lib/cast.ts
+++ b/client/src/lib/cast.ts
@@ -1,0 +1,109 @@
+type CastVideoOptions = {
+  url: string;
+  title: string;
+  channel: string;
+  topic: string;
+};
+
+export type CastConsentChoice = 'cancel' | 'once' | 'always';
+type ConsentProvider = () => Promise<CastConsentChoice>;
+
+const CONSENT_TTL_MS = 90 * 24 * 60 * 60 * 1000; // ~ 90 days
+
+export function isChromeBasedBrowser(): boolean {
+  return typeof window !== 'undefined' && !!window.chrome;
+}
+
+let consentProvider: ConsentProvider | null = null;
+
+export function setCastConsentProvider(provider: ConsentProvider) {
+  consentProvider = provider;
+}
+
+async function ensureConsent(): Promise<boolean> {
+  try {
+    if (localStorage.getItem('castConsent') === 'true') {
+      // After 90 days ask the user again, to avoid having stale consent from a long time ago.
+      const at = parseInt(localStorage.getItem('castConsentAt') ?? '0', 10);
+      if (!isNaN(at) && Date.now() - at < CONSENT_TTL_MS) return true;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  if (!consentProvider) return false;
+  const choice = await consentProvider();
+  if (choice === 'cancel') return false;
+  if (choice === 'always') {
+    try {
+      localStorage.setItem('castConsent', 'true');
+      localStorage.setItem('castConsentAt', Date.now().toString());
+    } catch {
+      /* ignore */
+    }
+  }
+  return true;
+}
+
+let sdkPromise: Promise<void> | null = null;
+
+function loadSdk(): Promise<void> {
+  if (sdkPromise) return sdkPromise;
+  sdkPromise = new Promise<void>((resolve, reject) => {
+    window.__onGCastApiAvailable = (isAvail: boolean) => {
+      if (!isAvail) {
+        reject(new Error('Cast API not available'));
+        return;
+      }
+      const ctx = cast.framework.CastContext.getInstance();
+      ctx.setOptions({
+        autoJoinPolicy: chrome.cast.AutoJoinPolicy.PAGE_SCOPED,
+        receiverApplicationId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
+      });
+      resolve();
+    };
+    const script = document.createElement('script');
+    script.src = 'https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1';
+    script.setAttribute('data-cast-sdk', '');
+    script.onerror = () => reject(new Error('Failed to load Cast SDK'));
+    document.head.appendChild(script);
+  });
+  return sdkPromise;
+}
+
+export async function castVideo(opts: CastVideoOptions): Promise<void> {
+  if (!(await ensureConsent())) return;
+
+  try {
+    await loadSdk();
+  } catch (e) {
+    console.warn('Chromecast SDK unavailable:', e);
+    return;
+  }
+
+  const ctx = cast.framework.CastContext.getInstance();
+  let session = ctx.getCurrentSession();
+  if (!session) {
+    try {
+      await ctx.requestSession();
+    } catch {
+      console.warn('No Cast session available or user cancelled the Cast dialog.');
+      return;
+    }
+    session = ctx.getCurrentSession();
+  }
+  if (!session) return;
+
+  const mediaInfo = new chrome.cast.media.MediaInfo(opts.url, opts.url.endsWith('.m3u8') ? 'application/x-mpegURL' : 'video/mp4');
+  const metadata = new chrome.cast.media.GenericMediaMetadata();
+  metadata.title = opts.title;
+  metadata.subtitle = `${opts.channel} – ${opts.topic}`;
+  mediaInfo.metadata = metadata;
+
+  const request = new chrome.cast.media.LoadRequest(mediaInfo);
+  request.autoplay = true;
+
+  const err = await session.loadMedia(request);
+  // TODO: surface this to the user via a toast/snackbar once such a component exists — currently fails silently from their perspective.
+  if (err) console.error('Cast loadMedia error:', err);
+}

--- a/client/src/lib/components/CastConsentDialog.svelte
+++ b/client/src/lib/components/CastConsentDialog.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { CastConsentChoice } from '$lib/cast';
+  import Button from './Button.svelte';
+  import Dialog from './Dialog.svelte';
+
+  let dialog: Dialog;
+  let resolver: ((choice: CastConsentChoice) => void) | null = null;
+
+  export function show(onChoice: (choice: CastConsentChoice) => void) {
+    if (resolver) {
+      onChoice('cancel');
+      return;
+    }
+    resolver = onChoice;
+    dialog.show();
+  }
+
+  function choose(choice: CastConsentChoice) {
+    const r = resolver;
+    resolver = null;
+    dialog.close();
+    r?.(choice);
+  }
+</script>
+
+<Dialog bind:this={dialog} title="Google Cast" icon="cast" onclose={() => resolver && choose('cancel')}>
+  <p class="mb-6 text-gray-600 dark:text-gray-300">Für die Nutzung von <i>Google Cast (Chromecast)</i> muss ein externer Inhalt von Google eingebunden werden.</p>
+  <div class="flex flex-wrap justify-end gap-3">
+    <Button variant="secondary" onclick={() => choose('cancel')}>Abbrechen</Button>
+    <Button variant="secondary" onclick={() => choose('once')}>Fortfahren</Button>
+    <Button variant="success" onclick={() => choose('always')}>Fortfahren und nicht mehr fragen</Button>
+  </div>
+</Dialog>

--- a/client/src/lib/components/VideoActions.svelte
+++ b/client/src/lib/components/VideoActions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ResultEntry, VideoPayload, VideoQuality } from '$lib/types';
   import { formatBytes, playVideoInNewWindow, trackEvent } from '$lib/utils';
+  import { castVideo, isChromeBasedBrowser } from '$lib/cast';
   import Icon from './Icon.svelte';
 
   let {
@@ -20,6 +21,8 @@
     { key: 'url_video', name: 'SD' },
     { key: 'url_video_low', name: 'LQ' },
   ];
+
+  const showCastButton = isChromeBasedBrowser();
 
   let sizes = $state<Record<VideoQuality | 'subtitle', string>>({ HD: '? MB', SD: '? MB', LQ: '? MB', subtitle: '? MB' });
   let sizesFetched = $state(false);
@@ -81,6 +84,16 @@
       topic: entry.topic,
       title: entry.title,
       quality,
+    });
+  }
+
+  async function cast(event: MouseEvent, url: string) {
+    event.stopPropagation();
+    await castVideo({
+      channel: entry.channel,
+      topic: entry.topic,
+      title: entry.title,
+      url,
     });
   }
 
@@ -213,6 +226,27 @@
           {/if}
         </div>
       </div>
+      {#if showCastButton}
+        <div>
+          <h4 class="flex items-center gap-2 font-semibold mb-3">
+            <Icon icon="cast" />
+            Chromecast
+          </h4>
+          <div class="flex gap-x-2 font-bold">
+            {#each qualities as q}
+              {@const url = entry[q.key] as string}
+              {#if url}
+                <button
+                  class="action-btn"
+                  title={`${q.name} auf Chromecast abspielen`}
+                  onclick={(e) => cast(e, url)}>
+                  {q.name}
+                </button>
+              {/if}
+            {/each}
+          </div>
+        </div>
+      {/if}
     </div>
   </div>
 {/if}

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+interface Window {
+  __onGCastApiAvailable?: (isAvailable: boolean) => void;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,23 +2,26 @@ import path from 'node:path';
 
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import devtoolsJson from 'vite-plugin-devtools-json';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [tailwindcss(), svelte(), devtoolsJson()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, __dirname);
+  return {
+    plugins: [tailwindcss(), svelte(), devtoolsJson()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_PROXY_TARGET ?? 'http://localhost:8000/',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  resolve: {
-    alias: {
-      '$lib': path.resolve(__dirname, './src/lib')
+    resolve: {
+      alias: {
+        '$lib': path.resolve(__dirname, './src/lib')
+      }
     }
-  }
+  };
 });


### PR DESCRIPTION
This MR adds support for playing content on other devices via Google Cast / Chromecast.

This requires a script from Google to be included.

To maintain privacy, the suggested addition only loads this script on demand and only if the user agrees to this.

See https://github.com/mediathekview/mediathekviewweb/issues/391.

When reviewing, please keep in mind that this will only work in Chromium-based Browsers. This is a deliberate requirement coming from Google.