### PR TITLE
feat: add /api/topics endpoint analogous to /api/channels

### DIFF
--- a/server/SearchEngine.ts
+++ b/server/SearchEngine.ts
@@ -50,6 +50,28 @@ export class SearchEngine {
     return (response.body.aggregations.channels as TermsAggregation).buckets.map((bucket) => String(bucket.key));
   }
 
+  async getTopics(channel?: string): Promise<string[]> {
+    const filter = channel ? { term: { "channel.keyword": channel } } : undefined;
+    const response = await this.client.search({
+      index: OPENSEARCH_INDEX,
+      size: 0,
+      body: {
+        ...(filter ? { query: { bool: { filter } } } : {}),
+        aggs: {
+          topics: {
+            terms: {
+              field: "topic.keyword",
+              size: 10000,
+              order: { _key: "asc" }
+            }
+          }
+        }
+      }
+    });
+
+    return (response.body.aggregations.topics as TermsAggregation).buckets.map((bucket) => String(bucket.key));
+  }
+
   async getDescription(id: string): Promise<string> {
     try {
       const response = await this.client.get({ index: OPENSEARCH_INDEX, id });

--- a/server/app.ts
+++ b/server/app.ts
@@ -129,6 +129,24 @@ import { VALKEY_KEYS } from './keys';
     }
   });
 
+  app.get('/api/topics', async (req, res) => {
+    const channel = req.query.channel as string | undefined;
+    try {
+      const topics = await searchEngine.getTopics(channel);
+      res.json({
+        error: null,
+        topics: topics
+      });
+    }
+    catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      res.status(500).json({
+        error: errorMessage,
+        topics: null
+      });
+    }
+  });
+
   app.get('/api/content-length', async (req, res) => {
     const url = req.query.url as string;
 


### PR DESCRIPTION
 Adds a new `GET /api/topics` endpoint that returns all unique topics, optionally filtered by channel (`?channel=ARD`).

 The implementation follows the same pattern as the existing `/api/channels` endpoint, using a Terms Aggregation on `topic.keyword` with alphabetical ordering. Size is set to 10000 to cover all unique topics.

Closes #400